### PR TITLE
Example for using Calcite with PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+.idea/
+*.iml
+

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,11 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>5.1.35</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.4-1201-jdbc41</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/org/ethz/systemsgroup/calcite/CalcitePostgreSQL.java
+++ b/src/main/java/org/ethz/systemsgroup/calcite/CalcitePostgreSQL.java
@@ -1,0 +1,61 @@
+package org.ethz.systemsgroup.calcite;
+
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.commons.dbcp.BasicDataSource;
+
+import java.sql.*;
+
+/**
+ * Created by kentsay on 7/6/15.
+ */
+public class CalcitePostgreSQL {
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        // creates a calcite driver so queries go through it
+        Class.forName("org.apache.calcite.jdbc.Driver");
+        Connection connection =
+                DriverManager.getConnection("jdbc:calcite:");
+        CalciteConnection calciteConnection =
+                connection.unwrap(CalciteConnection.class);
+
+        // creating mysql connection
+        Class.forName("org.postgresql.Driver");
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setUrl("jdbc:postgresql://127.0.0.1/demo");
+
+        dataSource.setUsername("kentsay");
+        dataSource.setPassword("kentsay");
+        dataSource.setDefaultCatalog("demo");
+
+        // The connection is completely empty until JdbcSchema.create registers a Java object as a schema and its collection test as tables
+        JdbcSchema jdbcSchema = JdbcSchema.create(calciteConnection.getRootSchema(), "demo", dataSource, null, "demo");
+
+        // By list table name from jdbcSchema interface, you can make sure what table you have in postgresql
+        for(String table: jdbcSchema.getTableNames()) {
+            System.out.println(table);
+        }
+        // adding schema to connection
+        calciteConnection.getRootSchema().add("demo", jdbcSchema);
+
+        // creating statement and executing
+        Statement statement = calciteConnection.createStatement();
+        ResultSet resultSet =
+                statement.executeQuery("select *\n"
+                        + "from \"demo\".\"tenants\"");
+        final StringBuilder buf = new StringBuilder();
+        while (resultSet.next()) {
+            int n = resultSet.getMetaData().getColumnCount();
+            for (int i = 1; i <= n; i++) {
+                buf.append(i > 1 ? "; " : "")
+                        .append(resultSet.getMetaData().getColumnLabel(i))
+                        .append("=")
+                        .append(resultSet.getObject(i));
+            }
+            System.out.println(buf.toString());
+            buf.setLength(0);
+        }
+        resultSet.close();
+        statement.close();
+        connection.close();
+    }
+}


### PR DESCRIPTION
Hi Renato, 

Here is a example of using Calcite with PostgreSQL based on your example. The reason it didn't work out last week is because there are some trouble with Calcite reading schema in PostgreSQL. After I used JdbcSchema in Calcite to list out all the schema and table name, I can then execute query from Calcite to PostgreSQL.

Ken
